### PR TITLE
Replace gcc with cc crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+/target/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ include = ["Cargo.toml", "LICENSE", "README.md", "build.rs", "src/lib.rs", "src/
 libc = "0.2"
 
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0"

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,7 @@
-extern crate gcc;
+extern crate cc;
 
 fn main() {
-    gcc::compile_library("liberrno.a", &["src/errno.c"]);
+    cc::Build::new()
+        .file("src/errno.c")
+        .compile("liberrno.a");
 }


### PR DESCRIPTION
The gcc crate is deprecated, this updates the build to the cc crate.